### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,8 @@ cd mcp && npm run build
 - [AI developer tools overview](https://www.courier.com/docs/tools/ai-onboarding/)
 - [Courier Node SDK](https://github.com/trycourier/courier-node)
 - [MCP protocol spec](https://modelcontextprotocol.io/)
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/trycourier-courier-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/trycourier-courier-mcp).