### PR TITLE
feat(mcp): eval-driven tool improvements — descriptions, defaults, cancel_automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Courier MCP Server
 
-The official [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [Courier](https://www.courier.com) notification API. It gives AI agents full access to the Courier API — send messages, manage profiles, debug deliveries, configure lists, and more — through 60 tools backed by the [`@trycourier/courier`](https://www.npmjs.com/package/@trycourier/courier) Node SDK.
+The official [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [Courier](https://www.courier.com) notification API. It gives AI agents full access to the Courier API — send messages, manage profiles, debug deliveries, configure lists, and more — through 110 tools backed by the [`@trycourier/courier`](https://www.npmjs.com/package/@trycourier/courier) Node SDK.
 
 ## Install
 
@@ -58,7 +58,7 @@ Then point your IDE at `http://localhost:3000` with the same config format above
 
 ## Tools
 
-59 default tools organized by API resource, plus 1 diagnostic tool available in local installs.
+109 default tools organized by API resource, plus 1 diagnostic tool available in local installs.
 
 ### Default tools
 
@@ -66,20 +66,24 @@ Then point your IDE at `http://localhost:3000` with the same config format above
 |----------|-------|
 | **Send** | `send_message`, `send_message_template`, `send_message_to_list`, `send_message_to_list_template` |
 | **Messages** | `list_messages`, `get_message`, `get_message_content`, `get_message_history`, `cancel_message` |
-| **Profiles** | `get_user_profile_by_id`, `create_or_merge_user`, `replace_profile`, `delete_profile`, `get_user_list_subscriptions`, `subscribe_user_to_lists`, `delete_user_list_subscriptions` |
-| **Lists** | `list_lists`, `get_list`, `get_list_subscribers`, `create_list`, `subscribe_user_to_list`, `unsubscribe_user_from_list` |
+| **Profiles** | `get_user_profile_by_id`, `create_or_merge_user`, `replace_profile`, `patch_profile`, `delete_profile`, `get_user_list_subscriptions`, `subscribe_user_to_lists`, `delete_user_list_subscriptions` |
+| **Lists** | `list_lists`, `get_list`, `get_list_subscribers`, `create_list`, `delete_list`, `restore_list`, `subscribe_user_to_list`, `unsubscribe_user_from_list`, `bulk_subscribe_to_list`, `add_subscribers_to_list` |
 | **Audiences** | `get_audience`, `list_audience_members`, `list_audiences`, `update_audience`, `delete_audience` |
-| **Notifications** | `list_notifications`, `get_notification_content`, `get_notification_draft_content` |
-| **Brands** | `create_brand`, `get_brand`, `list_brands` |
+| **Notifications** | `list_notifications`, `get_notification`, `get_notification_content`, `get_notification_draft_content`, `create_notification`, `replace_notification`, `archive_notification`, `publish_notification`, `list_notification_versions`, `list_notification_checks`, `update_notification_checks`, `put_notification_content`, `put_notification_element`, `put_notification_locale`, `cancel_notification_submission` |
+| **Brands** | `create_brand`, `get_brand`, `list_brands`, `update_brand`, `delete_brand` |
 | **Auth** | `generate_jwt_for_user` |
-| **User Tokens** | `list_user_push_tokens`, `get_user_push_token`, `create_or_replace_user_push_token` |
+| **Device Tokens** | `list_user_push_tokens`, `get_user_push_token`, `create_or_replace_user_push_token`, `bulk_add_user_tokens`, `patch_user_token`, `delete_user_token` |
 | **Docs** | `courier_installation_guide` |
-| **Automations** | `invoke_automation_template`, `invoke_ad_hoc_automation` |
+| **Automations** | `invoke_automation_template`, `invoke_ad_hoc_automation`, `list_automations`, `cancel_automation` |
 | **Bulk** | `create_bulk_job`, `add_bulk_users`, `run_bulk_job`, `get_bulk_job`, `list_bulk_users` |
 | **Audit Events** | `get_audit_event`, `list_audit_events` |
 | **Inbound** | `track_inbound_event` |
-| **Tenants** | `get_tenant`, `create_or_update_tenant`, `list_tenants`, `delete_tenant` |
-| **Users** | `get_user_preferences`, `update_user_preference_topic`, `list_user_tenants`, `add_user_to_tenant`, `remove_user_from_tenant` |
+| **Tenants** | `get_tenant`, `create_or_update_tenant`, `list_tenants`, `delete_tenant`, `list_tenant_users`, `update_tenant_preference`, `delete_tenant_preference`, `list_tenant_templates`, `get_tenant_template`, `replace_tenant_template`, `publish_tenant_template`, `get_tenant_template_version` |
+| **Users** | `get_user_preferences`, `get_user_preference_topic`, `update_user_preference_topic`, `list_user_tenants`, `add_user_to_tenant`, `remove_user_from_tenant`, `bulk_add_user_tenants`, `remove_all_user_tenants` |
+| **Routing Strategies** | `create_routing_strategy`, `get_routing_strategy`, `replace_routing_strategy`, `archive_routing_strategy`, `list_routing_strategies`, `list_routing_strategy_notifications` |
+| **Journeys** | `list_journeys`, `invoke_journey` |
+| **Requests** | `archive_request` |
+| **Providers** | `list_providers`, `get_provider`, `list_provider_catalog`, `create_provider`, `update_provider`, `delete_provider` |
 | **Translations** | `get_translation`, `update_translation` |
 
 ### Diagnostic tools (local only)

--- a/mcp/src/__tests__/integration.test.ts
+++ b/mcp/src/__tests__/integration.test.ts
@@ -98,7 +98,7 @@ describe('MCP protocol', () => {
 
   it('listTools returns all tools with descriptions', async () => {
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(109);
+    expect(tools.length).toBe(110);
     for (const tool of tools) {
       expect(tool.name).toBeTruthy();
       expect(tool.description).toBeTruthy();

--- a/mcp/src/__tests__/tools-coverage.test.ts
+++ b/mcp/src/__tests__/tools-coverage.test.ts
@@ -60,8 +60,8 @@ describe('Tool coverage - one call per tool', () => {
   // --- Brands ---
 
   it('create_brand', async () => {
-    await client.callTool({ name: 'create_brand', arguments: { name: 'Acme' } });
-    expect(mockCourier.brands.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Acme' }));
+    await client.callTool({ name: 'create_brand', arguments: { name: 'Acme', settings: { colors: { primary: '#000000', secondary: '#ffffff' } } } });
+    expect(mockCourier.brands.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Acme', settings: { colors: { primary: '#000000', secondary: '#ffffff' } } }));
   });
 
   it('get_brand', async () => {
@@ -824,7 +824,7 @@ describe('Tool filtering - registerToolIfNeeded respects availableTools', () => 
       const tools = await client.listTools();
       const names = tools.tools.map((t: any) => t.name);
       expect(names).not.toContain('get_environment_config');
-      expect(names.length).toBe(108);
+      expect(names.length).toBe(109);
     } finally {
       await cleanup();
     }
@@ -837,7 +837,7 @@ describe('Tool filtering - registerToolIfNeeded respects availableTools', () => 
       const tools = await client.listTools();
       const names = tools.tools.map((t: any) => t.name);
       expect(names).toContain('get_environment_config');
-      expect(names.length).toBe(109);
+      expect(names.length).toBe(110);
     } finally {
       await cleanup();
     }

--- a/mcp/src/tools/automations-tools.ts
+++ b/mcp/src/tools/automations-tools.ts
@@ -2,19 +2,74 @@ import { z } from "zod";
 import { CourierMcpTools } from "./courier-mcp-tools.js";
 import { handleToolCall } from "../utils/error-handler.js";
 
+const automationStepSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('send'),
+    template: z.string().optional().describe('Notification template ID or key'),
+    brand: z.string().optional(),
+    data: z.record(z.any()).optional(),
+    profile: z.record(z.any()).optional(),
+    recipient: z.string().optional(),
+    if: z.string().optional().describe('Condition expression'),
+  }),
+  z.object({
+    action: z.literal('send-list'),
+    list: z.string().describe('List ID to send to'),
+    template: z.string().optional(),
+    brand: z.string().optional(),
+    data: z.record(z.any()).optional(),
+    if: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal('delay'),
+    duration: z.string().optional().describe('ISO 8601 duration (e.g. "PT1H" for 1 hour)'),
+    until: z.string().optional().describe('ISO 8601 timestamp to wait until'),
+    if: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal('cancel'),
+    cancelation_token: z.string().describe('The token set when the original automation was invoked (single "l" spelling)'),
+    if: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal('update-profile'),
+    recipient_id: z.string().optional(),
+    merge: z.enum(['none', 'overwrite', 'soft-merge', 'replace']).optional(),
+    profile: z.record(z.any()).optional(),
+    if: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal('invoke'),
+    template: z.string().describe('Automation template ID to invoke'),
+    if: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal('fetch-data'),
+    webhook: z.object({
+      url: z.string(),
+      method: z.enum(['GET', 'POST', 'PUT', 'PATCH']).optional(),
+      headers: z.record(z.string()).optional(),
+      body: z.record(z.any()).optional(),
+    }).describe('HTTP request configuration'),
+    merge_strategy: z.enum(['replace', 'overwrite', 'soft-merge']).optional(),
+    if: z.string().optional(),
+  }),
+]);
+
 export class AutomationsTools extends CourierMcpTools {
 
   static readonly tools: string[] = [
     'invoke_automation_template',
     'invoke_ad_hoc_automation',
     'list_automations',
+    'cancel_automation',
   ];
 
   public register() {
 
     this.registerToolIfNeeded(
       AutomationsTools.tools[0],
-      'Invoke an automation run from an existing automation template.',
+      'Invoke an automation run from an existing automation template. Call list_automations first to get the template_id. Example: { template_id: "auto-onboarding", recipient: "user-123", data: { plan: "pro" } }.',
       {
         template_id: z.string().describe('The automation template ID'),
         recipient: z.string().describe('Recipient user ID'),
@@ -38,12 +93,12 @@ export class AutomationsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       AutomationsTools.tools[1],
-      'Invoke an ad-hoc automation with inline steps (no template needed).',
+      'Invoke an ad-hoc automation with inline steps. Valid step actions: send, send-list, delay, cancel, update-profile, invoke, fetch-data. To cancel a previously started automation, use the cancel_automation tool instead.',
       {
         automation: z.object({
-          steps: z.array(z.any()).describe('Array of automation step objects'),
-          cancelation_token: z.string().optional().describe('Token for cancelling the automation'),
-        }).describe('The automation definition'),
+          steps: z.array(automationStepSchema).describe('Ordered array of automation steps'),
+          cancelation_token: z.string().optional().describe('Token for cancelling this automation later (single "l" spelling)'),
+        }).describe('The automation definition with typed steps'),
         brand: z.string().optional(),
         data: z.record(z.any()).optional(),
         profile: z.record(z.any()).optional(),
@@ -66,7 +121,7 @@ export class AutomationsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       AutomationsTools.tools[2],
-      'List automation templates in the workspace. Optionally filter by version.',
+      'List automation templates in the workspace. Always call this first to discover template_id values before calling invoke_automation_template. Optionally filter by version.',
       {
         cursor: z.string().optional().describe('Pagination cursor'),
         version: z.enum(['published', 'draft']).optional().describe('Filter by version state'),
@@ -80,6 +135,24 @@ export class AutomationsTools extends CourierMcpTools {
         });
       },
       { readOnlyHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      AutomationsTools.tools[3],
+      'Cancel a running automation by its cancelation_token. This invokes a second ad-hoc automation with a single cancel step. The token must match the cancelation_token set when the original automation was started. Note: spelling is "cancelation_token" (single "l").',
+      {
+        cancelation_token: z.string().describe('The cancelation_token that was set when the automation was originally invoked'),
+      },
+      async ({ cancelation_token }) => {
+        return handleToolCall(() => {
+          return this.mcp.courier.automations.invoke.invokeAdHoc({
+            automation: {
+              steps: [{ action: 'cancel', cancelation_token }],
+            },
+          } as any);
+        });
+      },
+      { readOnlyHint: false, idempotentHint: true }
     );
   }
 }

--- a/mcp/src/tools/brands-tools.ts
+++ b/mcp/src/tools/brands-tools.ts
@@ -16,22 +16,26 @@ export class BrandsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       BrandsTools.tools[0],
-      'Create a new brand with name, colors, and email/inapp settings.',
+      'Create a new brand. The API requires settings — omitting it returns a 400. If you do not have specific brand colors, omit settings and a safe default will be used automatically (black primary, white secondary). Example: { name: "Acme", settings: { colors: { primary: "#1a73e8", secondary: "#ffffff" } } }.',
       {
         name: z.string().describe('Brand display name'),
         id: z.string().optional().describe('Optional brand ID; auto-generated if omitted'),
         settings: z.object({
-          colors: z.record(z.any()).optional(),
-          inapp: z.record(z.any()).optional(),
-          email: z.record(z.any()).optional(),
-        }).optional().describe('Brand settings (colors, email, inapp)'),
+          colors: z.object({
+            primary: z.string().describe('Primary brand color (hex, e.g. "#1a73e8")'),
+            secondary: z.string().describe('Secondary brand color (hex, e.g. "#ffffff")'),
+            tertiary: z.string().optional().describe('Tertiary brand color (hex)'),
+          }).optional().describe('Brand colors'),
+          inapp: z.record(z.any()).optional().describe('In-app notification settings'),
+          email: z.record(z.any()).optional().describe('Email template settings (header, footer)'),
+        }).optional().describe('Brand appearance settings. If omitted, defaults to { colors: { primary: "#000000", secondary: "#ffffff" } }.'),
         snippets: z.record(z.any()).optional().describe('Brand snippets'),
       },
       async ({ name, id, settings, snippets }) => {
         return handleToolCall(() => {
-          const body: any = { name };
+          const effectiveSettings = settings ?? { colors: { primary: '#000000', secondary: '#ffffff' }, inapp: {}, email: {} };
+          const body: any = { name, settings: effectiveSettings };
           if (id) body.id = id;
-          if (settings) body.settings = settings;
           if (snippets) body.snippets = snippets;
           return this.mcp.courier.brands.create(body);
         });

--- a/mcp/src/tools/journeys-tools.ts
+++ b/mcp/src/tools/journeys-tools.ts
@@ -13,7 +13,7 @@ export class JourneysTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       JourneysTools.tools[0],
-      'List journey templates in the workspace. Optionally filter by version (published or draft).',
+      'List journey templates in the workspace. Optionally filter by version (published or draft). Note: journey creation, editing, and publishing are not available via MCP — use the Journeys REST API directly (POST /journeys, PUT /journeys/{id}, POST /journeys/{id}/publish) or the Courier Studio UI. This tool is for discovery only.',
       {
         cursor: z.string().optional().describe('Pagination cursor'),
         version: z.enum(['published', 'draft']).optional().describe('Filter by version state. Defaults to published.'),
@@ -31,7 +31,7 @@ export class JourneysTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       JourneysTools.tools[1],
-      'Invoke a journey run from a journey template. Triggers the automation workflow for the specified user.',
+      'Invoke a journey run from a journey template. Call list_journeys first to find the template_id. Example: { template_id: "j-onboarding", user_id: "user-123", data: { plan: "pro" } }.',
       {
         template_id: z.string().describe('The journey template ID'),
         user_id: z.string().optional().describe('Recipient user ID. Can also be resolved from profile or data.'),

--- a/mcp/src/tools/notifications-tools.ts
+++ b/mcp/src/tools/notifications-tools.ts
@@ -71,7 +71,7 @@ export class NotificationsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       NotificationsTools.tools[3],
-      "Create a notification template with name, tags, brand, subscription, routing, and content.",
+      "Create a V2 notification template. name is required. Provide content inline or set it immediately after creation via put_notification_content. To send with this template you must publish it first via publish_notification (or pass state: 'PUBLISHED' on create). Link a routing strategy via notification.routing.strategy_id to control which channels are used. Example: { notification: { name: 'welcome-email', tags: [], brand: null, subscription: null, routing: { strategy_id: 'rs_01abc' }, content: { version: '2022-01-01', elements: [] } } }.",
       {
         notification: notificationTemplatePayload.describe('Notification template payload'),
         state: z.enum(['DRAFT', 'PUBLISHED']).optional().describe('Template state after creation (defaults to DRAFT)'),
@@ -160,7 +160,7 @@ export class NotificationsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       NotificationsTools.tools[8],
-      "Publish a notification template. Optionally publish a specific historical version instead of the current draft.",
+      "Publish a notification template, making it available for sending. Must be called before send_message_template unless the template was created with state: 'PUBLISHED'. Publishes the current draft by default; pass version (e.g. 'v001') to publish a specific historical version. Returns 204 on success.",
       {
         notification_id: z.string().describe('The notification template ID to publish'),
         version: z.string().optional().describe('Historical version to publish (e.g. v001); omit to publish current draft'),
@@ -218,7 +218,7 @@ export class NotificationsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       NotificationsTools.tools[11],
-      'Replace the elemental content of a V2 notification template. Overwrites all elements.',
+      'Replace the elemental content of a V2 notification template. Overwrites all elements. Use channel elements to target specific channels. Multi-channel example: elements: [{ type: "channel", channel: "email", elements: [{ type: "meta", title: "Hello" }, { type: "text", content: "Email body" }] }, { type: "channel", channel: "push", elements: [{ type: "meta", title: "Hello" }, { type: "text", content: "Push body" }] }, { type: "channel", channel: "inbox", elements: [{ type: "text", content: "Inbox plain text only" }] }].',
       {
         notification_id: z.string().describe('The notification template ID (nt_ prefix)'),
         elements: z.array(z.record(z.any())).describe('Array of elemental content nodes'),
@@ -267,7 +267,7 @@ export class NotificationsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       NotificationsTools.tools[13],
-      'Set locale-specific content overrides for a V2 notification template.',
+      'Set locale-specific content overrides for a V2 notification template. Each element override must reference an existing element by its id. Example for Spanish locale: { notification_id: "nt_01abc", locale_id: "es", elements: [{ id: "elem_meta_1", title: "Restablecer contraseña" }, { id: "elem_text_1", content: "Haga clic en el enlace para restablecer su contraseña." }] }.',
       {
         notification_id: z.string().describe('The notification template ID (nt_ prefix)'),
         locale_id: z.string().describe('Locale identifier (e.g. es, fr, pt-BR)'),

--- a/mcp/src/tools/send-tools.ts
+++ b/mcp/src/tools/send-tools.ts
@@ -42,7 +42,7 @@ export class SendTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       SendTools.tools[1],
-      'Send a message to a user using a pre-configured notification template. Optionally pass data and routing.',
+      'Send a message to a user using a published notification template. The template must be published before sending — call publish_notification first if needed. Example: { user_id: "user-123", template: "nt_01abc123", data: { name: "Alex", resetUrl: "https://app.example.com/reset" } }.',
       {
         user_id: z.string().describe('The recipient user ID'),
         template: z.string().describe('Template ID or notification slug'),

--- a/mcp/src/tools/tenants-tools.ts
+++ b/mcp/src/tools/tenants-tools.ts
@@ -122,10 +122,10 @@ export class TenantsTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       TenantsTools.tools[5],
-      'Create or replace default notification preference for a topic on a tenant.',
+      'Set the default notification preference for a subscription topic on a tenant. This controls tenant-level defaults — it does NOT set per-user preferences (use the user preferences API for that). The topic_id must already exist as a subscription topic in the workspace; a 404 means the topic has not been created yet. Example: { tenant_id: "acme", topic_id: "marketing-updates", status: "OPTED_IN", has_custom_routing: true, custom_routing: ["email", "push"] }.',
       {
         tenant_id: z.string().describe('The tenant ID'),
-        topic_id: z.string().describe('The subscription topic ID'),
+        topic_id: z.string().describe('The subscription topic ID — must already exist in the workspace. A 404 response means the topic does not exist; create it in the Preferences Editor first.'),
         status: z.enum(['OPTED_IN', 'OPTED_OUT', 'REQUIRED']).describe('Subscription status for the topic'),
         custom_routing: z
           .array(TenantsTools.channelClassification)


### PR DESCRIPTION
## Summary

- **Brands** — `create_brand`: inject safe default settings when omitted (`{ colors: { primary: "#000000", secondary: "#ffffff" } }`) to prevent 400s; update description with inline example
- **Tenants** — `update_tenant_preference`: clarify tenant-level vs user-level prefs, document that 404 means the topic doesn't exist yet, add full example payload
- **Notifications** — description polish across 4 tools:
  - `create_notification`: document `name` required, routing strategy link, publish-before-send requirement
  - `put_notification_content`: add multi-channel element example (email + push + inbox)
  - `publish_notification`: clarify must call before `send_message_template`
  - `put_notification_locale`: add locale override example
- **Send** — `send_message_template`: document publish requirement, add usage example
- **Automations** — `list_automations`: add "call this first" guidance; `invoke_automation_template`: add example; `invoke_ad_hoc_automation`: typed steps discriminated union (7 action types); `cancel_automation`: new tool wrapping cancel step pattern
- **Journeys** — `list_journeys`: document that creation/publishing is API-only (SDK supports list + invoke only); `invoke_journey`: add "call list_journeys first" + example
- **Tests** — update tool count assertions for new `cancel_automation` tool (109 → 110)