### PR TITLE
chore: bump @trycourier/courier-mcp to 1.3.5

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trycourier/courier-mcp",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trycourier/courier-mcp",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-mcp",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Courier's official MCP package",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/trycourier/courier-mcp",
     "source": "github"
   },
-  "version": "1.3.4",
+  "version": "1.3.5",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary

- Bumps `mcp/package.json` and `server.json` from 1.3.4 to 1.3.5 so Publish NPM can publish the journey CRUD + template tools from #35
- Unblocks the chained **Bump MCP in Services** workflow, which opens a dep-bump PR in `trycourier/services` for the public hosted MCP at `mcp.courier.com`