### PR TITLE
fix: publish to npm via Trusted Publisher OIDC

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Node 22 ships npm 10.x; trusted publishing requires npm 11.5.1+ (see npm docs).
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         run: |
           PACKAGE_NAME="$(jq -r '.name' package.json)"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,6 +2,9 @@
 # the latest published version. Runs on every push to main, on GitHub
 # release, or via manual dispatch. After npm publish, publishes the
 # server metadata to the MCP Registry via OIDC authentication.
+#
+# npm publish uses Trusted Publisher OIDC (package settings → publish-npm.yml).
+# Requires Node 22+ and npm CLI 11.5.1+ for OIDC trusted publishing.
 name: Publish NPM
 on:
   workflow_dispatch:
@@ -34,7 +37,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm install
@@ -47,28 +51,27 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
-
           PACKAGE_NAME="$(jq -r '.name' package.json)"
           VERSION="$(jq -r '.version' package.json)"
           PUBLISHED="$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "")"
 
           if [ "$VERSION" = "$PUBLISHED" ]; then
             echo "$PACKAGE_NAME@$VERSION is already published, skipping."
+            echo "npm_skip=true" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          echo "Publishing $PACKAGE_NAME@$VERSION (current npm: ${PUBLISHED:-none})"
-          npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          echo "Publishing $PACKAGE_NAME@$VERSION (current npm: ${PUBLISHED:-none}) via Trusted Publisher OIDC"
+          npm publish --provenance --access public
 
       - name: Install mcp-publisher
+        if: env.npm_skip != 'true'
         working-directory: .
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       - name: Publish to MCP Registry
+        if: env.npm_skip != 'true'
         working-directory: .
         run: |
           ./mcp-publisher login github-oidc

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,10 +1,6 @@
-# Publishes to npm when the version in mcp/package.json differs from
-# the latest published version. Runs on every push to main, on GitHub
-# release, or via manual dispatch. After npm publish, publishes the
-# server metadata to the MCP Registry via OIDC authentication.
-#
-# npm publish uses Trusted Publisher OIDC (package settings → publish-npm.yml).
-# Requires Node 22+ and npm CLI 11.5.1+ for OIDC trusted publishing.
+# Publishes to npm when mcp/package.json version differs from the latest on the registry.
+# Uses npm Trusted Publisher OIDC (package settings → publish-npm.yml on this repo).
+# No NPM_TOKEN — setup-node exchanges GitHub OIDC for a short-lived publish credential.
 name: Publish NPM
 on:
   workflow_dispatch:
@@ -37,7 +33,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -49,10 +45,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Node 22 ships npm 10.x; trusted publishing requires npm 11.5.1+ (see npm docs).
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Publish to NPM
         run: |
           PACKAGE_NAME="$(jq -r '.name' package.json)"
@@ -60,12 +52,12 @@ jobs:
           PUBLISHED="$(npm view "$PACKAGE_NAME" version 2>/dev/null || echo "")"
 
           if [ "$VERSION" = "$PUBLISHED" ]; then
-            echo "$PACKAGE_NAME@$VERSION is already published, skipping."
+            echo "$PACKAGE_NAME@$VERSION is already on npm, skipping publish."
             echo "npm_skip=true" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          echo "Publishing $PACKAGE_NAME@$VERSION (current npm: ${PUBLISHED:-none}) via Trusted Publisher OIDC"
+          echo "Publishing $PACKAGE_NAME@$VERSION (npm latest: ${PUBLISHED:-none})"
           npm publish --provenance --access public
 
       - name: Install mcp-publisher

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trycourier/courier-mcp",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trycourier/courier-mcp",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -25,6 +25,14 @@
   ],
   "author": "Courier",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trycourier/courier-mcp.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "devDependencies": {
     "@types/node": "^24.0.14",
     "nodemon": "^3.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-mcp",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Courier's official MCP package",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/trycourier/courier-mcp",
     "source": "github"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary
- Switches **Publish to NPM** from `NPM_TOKEN` to OIDC trusted publishing (`setup-node` + `registry-url` + `id-token: write` + `npm publish --provenance`), matching npm Trusted Publisher config for workflow file `publish-npm.yml` on `trycourier/courier-mcp`
- Uses **Node 24** so CI ships npm 11+ for OIDC (no global npm upgrade step)
- Publishes only when `mcp/package.json` version differs from the latest on the registry
- Skips **Publish to MCP Registry** when npm publish is skipped so duplicate-version failures do not block **Bump MCP in Services**
- Adds `repository` and `publishConfig` to `mcp/package.json` for npm repo validation on OIDC publishes
- Bumps version **1.3.5 → 1.3.6** so merge publishes a new tarball and chains **Bump MCP in Services** (`1.3.5` is already on npm from a branch test)