### PR TITLE
fix: force-push services mcp-bump branch

### DIFF
--- a/.github/workflows/bump-services.yml
+++ b/.github/workflows/bump-services.yml
@@ -125,7 +125,8 @@ jobs:
           git checkout -B "$BRANCH"
           git add apps/mcp/package.json package-lock.json
           git commit -m "chore: bump @trycourier/courier-mcp to ^${VERSION}"
-          git push --force-with-lease origin "$BRANCH"
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git push --force origin "$BRANCH"
 
           EXISTING=$(gh pr list --repo trycourier/services --head "$BRANCH" --state open --json number -q '.[0].number')
           if [ -n "$EXISTING" ]; then


### PR DESCRIPTION
## Summary
- Replace `git push --force-with-lease` with `git fetch` + `git push --force` on bot-owned `mcp-bump-*` branches so refresh runs can update services PR #1236

After merge, re-run **Bump MCP in Services** with `refresh_services_pr: true`.