### PR TITLE
chore: set package homepage to courier.com

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trycourier/courier-mcp",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trycourier/courier-mcp",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -25,6 +25,7 @@
   ],
   "author": "Courier",
   "license": "MIT",
+  "homepage": "https://courier.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/trycourier/courier-mcp.git"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-mcp",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Courier's official MCP package",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "type": "git",
     "url": "https://github.com/trycourier/courier-mcp.git"
   },
-  "homepage": "https://www.courier.com"
+  "homepage": "https://courier.com",
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "type": "git",
     "url": "https://github.com/trycourier/courier-mcp.git"
   },
-  "homepage": "https://courier.com",
+  "homepage": "https://courier.com"
 }

--- a/server.json
+++ b/server.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/trycourier/courier-mcp",
     "source": "github"
   },
-  "version": "1.3.6",
+  "version": "1.3.7",
   "remotes": [
     {
       "type": "streamable-http",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.trycourier/courier",
   "title": "Courier",
   "description": "Send notifications, manage templates, and configure integrations with Courier.",
-  "websiteUrl": "https://www.courier.com",
+  "websiteUrl": "https://courier.com",
   "icons": [
     {
       "src": "https://www.courier.com/favicon-96x96.png",


### PR DESCRIPTION
## Summary
- Sets npm `homepage` to `https://courier.com` on `@trycourier/courier-mcp` and root `package.json`
- Updates MCP registry `websiteUrl` in `server.json`
- Fixes invalid trailing comma in root `package.json` (broke vitest/esbuild in CI)
- Bumps version **1.3.6 → 1.3.7** for publish on merge