### PR TITLE
fix(server): return 405 on GET / so MCP clients don't fail to open the SSE stream

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,8 +17,13 @@ app.post('/', (req: Request, res: Response, next: NextFunction) => {
   return statelessHandler(createServer)(req, res, next);
 });
 
-// Stateless mode doesn't support SSE streaming. Return 405 so MCP clients
-// know this endpoint exists but doesn't accept GET (instead of a confusing 404).
+// MCP clients open an OPTIONAL standalone GET SSE stream to receive
+// server-initiated messages. A stateless server never pushes anything on it, so
+// we don't offer one. The MCP SDK client treats a 405 here as the documented
+// "no SSE stream at this endpoint" signal and continues cleanly; it only fails
+// fatally ("Failed to open SSE stream") on other non-2xx codes — notably the
+// Express-default 404 you get when this route is missing entirely. So the route
+// must exist and answer 405.
 app.get('/', (_req: Request, res: Response) => {
   res.status(405).set('Allow', 'POST').send('SSE not supported on stateless server');
 });


### PR DESCRIPTION
## Problem

MCP clients (e.g. Cursor, Claude) fail to connect to the hosted Streamable HTTP server, looping with:

```
Streamable HTTP error: Failed to open SSE stream:
Tombstoning streamable HTTP transport after 5 consecutive session HTTP 404 responses; automatic retry disabled
```

MCP clients open an optional standalone `GET /` SSE stream for server-initiated messages. The hosted server had **no `GET /` route**, so Express returned its default **404**. The MCP SDK client (shared by Cursor and Claude) treats `404` — and any non-2xx except `405` — as a fatal *"Failed to open SSE stream"*, tearing the connection down and looping until it tombstones the transport and disables retry. `initialize`/`tools/list` ride the POST response so the client appears to connect, but the GET stream 404 kills the session.

## Fix

Ensure `GET /` exists and returns **`405`**. That is the SDK's documented "this endpoint offers no SSE stream" signal — the client handles it gracefully and moves on:

```js
// from @modelcontextprotocol/sdk client transport
// 405 indicates that the server does not offer an SSE stream at GET endpoint
// This is an expected case that should not trigger an error
if (response.status === 405) {
    return;
}
throw new StreamableHTTPError(response.status, `Failed to open SSE stream: ...`);
```

A stateless server never pushes server-initiated messages, so it genuinely has no stream to offer — `405` is the correct, spec-aligned answer. (An earlier draft served a `200` keep-alive SSE stream instead; that worked but told clients we *have* a push channel we don't, leaving them holding idle sockets with reconnection logic. Dropped in favor of the lighter, recommended `405`.)

## Verification

Drove the **real MCP SDK Streamable HTTP client** (`@modelcontextprotocol/sdk` v1.17.0 — the transport Cursor and Claude both use) against the relevant server states:

| Server `GET /` | Real SDK client result |
|---|---|
| **404** (no route — the deployed bug) | ❌ `Failed to open SSE stream: Not Found` — reproduces the logs exactly |
| **405** (this fix) | ✅ clean — connects, lists 110 tools, no error |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
