### PR TITLE
docs: correct default tool count in README (109 -> 123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then point your IDE at `http://localhost:3000` with the same config format above
 
 ## Tools
 
-109 default tools organized by API resource, plus 1 diagnostic tool available in local installs.
+123 default tools organized by API resource, plus 1 diagnostic tool available in local installs.
 
 ### Default tools
 


### PR DESCRIPTION
## What

The README's Tools section said **"109 default tools"**, but the registry — and the category table directly below it — actually lists **123 default tools**. Corrected the count.

## Why

The journey CRUD tools and journey-template sub-resource tools added across the 1.3.x releases brought the default set from 109 to **123**. With the local-only `get_environment_config` diagnostic that's **124 total**, which matches the figure already in the intro paragraph — so the doc was internally inconsistent.

## Verification

Built `CourierMcpToolsRegistry.defaultTools` from source and diffed every entry against the README category table:

- `defaultTools` = **123**, `allAvailableTools` = **124** (123 + 1 diagnostic), no duplicates
- README table ↔ actual tool set: **exact match**, nothing stale or missing

The published package is **1.3.7** (consistent across `mcp/package.json`, `server.json`, and npm latest) and already ships these 123 tools, so this is purely a docs correction — no version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
