### PR TITLE
feat: add MCP tools for preference sections, digests, and journey template content

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "courier",
   "version": "1.3.4",
-  "description": "Send notifications, manage users, and orchestrate messaging workflows. 124 tools for the full Courier API across email, SMS, push, chat, and in-app.",
+  "description": "Send notifications, manage users, and orchestrate messaging workflows. 141 tools for the full Courier API across email, SMS, push, chat, and in-app.",
   "author": {
     "name": "Courier",
     "email": "support@courier.com",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "courier",
   "version": "1.3.4",
-  "description": "Send notifications, manage users, and orchestrate messaging workflows. 124 tools for the full Courier API across email, SMS, push, chat, and in-app.",
+  "description": "Send notifications, manage users, and orchestrate messaging workflows. 141 tools for the full Courier API across email, SMS, push, chat, and in-app.",
   "author": {
     "name": "Courier",
     "email": "support@courier.com",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Courier MCP Server
 
-The official [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [Courier](https://www.courier.com) notification API. It gives AI agents full access to the Courier API — send messages, manage profiles, debug deliveries, configure lists, and more — through 124 tools backed by the [`@trycourier/courier`](https://www.npmjs.com/package/@trycourier/courier) Node SDK.
+The official [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [Courier](https://www.courier.com) notification API. It gives AI agents full access to the Courier API — send messages, manage profiles, debug deliveries, configure lists, and more — through 141 tools backed by the [`@trycourier/courier`](https://www.npmjs.com/package/@trycourier/courier) Node SDK.
 
 ## Install
 
@@ -58,7 +58,7 @@ Then point your IDE at `http://localhost:3000` with the same config format above
 
 ## Tools
 
-123 default tools organized by API resource, plus 1 diagnostic tool available in local installs.
+140 default tools organized by API resource, plus 1 diagnostic tool available in local installs.
 
 ### Default tools
 
@@ -79,9 +79,11 @@ Then point your IDE at `http://localhost:3000` with the same config format above
 | **Audit Events** | `get_audit_event`, `list_audit_events` |
 | **Inbound** | `track_inbound_event` |
 | **Tenants** | `get_tenant`, `create_or_update_tenant`, `list_tenants`, `delete_tenant`, `list_tenant_users`, `update_tenant_preference`, `delete_tenant_preference`, `list_tenant_templates`, `get_tenant_template`, `replace_tenant_template`, `publish_tenant_template`, `get_tenant_template_version`, `delete_tenant_template` |
-| **Users** | `get_user_preferences`, `get_user_preference_topic`, `update_user_preference_topic`, `list_user_tenants`, `add_user_to_tenant`, `remove_user_from_tenant`, `bulk_add_user_tenants`, `remove_all_user_tenants` |
+| **Users** | `get_user_preferences`, `get_user_preference_topic`, `update_user_preference_topic`, `delete_user_preference_topic`, `list_user_tenants`, `add_user_to_tenant`, `remove_user_from_tenant`, `bulk_add_user_tenants`, `remove_all_user_tenants` |
+| **Preference Sections** | `list_preference_sections`, `create_preference_section`, `get_preference_section`, `replace_preference_section`, `archive_preference_section`, `publish_preferences`, `list_preference_topics`, `create_preference_topic`, `get_preference_topic`, `replace_preference_topic`, `archive_preference_topic` |
+| **Digests** | `release_digest`, `list_digest_instances` |
 | **Routing Strategies** | `create_routing_strategy`, `get_routing_strategy`, `replace_routing_strategy`, `archive_routing_strategy`, `list_routing_strategies`, `list_routing_strategy_notifications` |
-| **Journeys** | `list_journeys`, `invoke_journey`, `create_journey`, `get_journey`, `replace_journey`, `publish_journey`, `archive_journey`, `list_journey_versions`, `list_journey_templates`, `create_journey_template`, `get_journey_template`, `replace_journey_template`, `archive_journey_template`, `publish_journey_template`, `list_journey_template_versions` |
+| **Journeys** | `list_journeys`, `invoke_journey`, `create_journey`, `get_journey`, `replace_journey`, `publish_journey`, `archive_journey`, `list_journey_versions`, `list_journey_templates`, `create_journey_template`, `get_journey_template`, `replace_journey_template`, `archive_journey_template`, `publish_journey_template`, `list_journey_template_versions`, `get_journey_template_content`, `put_journey_template_content`, `put_journey_template_locale` |
 | **Requests** | `archive_request` |
 | **Providers** | `list_providers`, `get_provider`, `list_provider_catalog`, `create_provider`, `update_provider`, `delete_provider` |
 | **Translations** | `get_translation`, `update_translation` |

--- a/mcp/src/__tests__/helpers.ts
+++ b/mcp/src/__tests__/helpers.ts
@@ -6,6 +6,12 @@ import { CourierMcpToolsRegistry } from '../utils/courier-mcp-tools-registry.js'
 
 export function createMockCourier() {
   return {
+    // Raw HTTP escape-hatch methods used by tools whose typed SDK resource is
+    // not yet published (preference sections, digests, journey template content).
+    get: vi.fn().mockResolvedValue({ items: [] }),
+    post: vi.fn().mockResolvedValue({ id: 'created-1' }),
+    put: vi.fn().mockResolvedValue({ id: 'updated-1' }),
+    delete: vi.fn().mockResolvedValue(undefined),
     send: { message: vi.fn().mockResolvedValue({ requestId: 'req-123' }) },
     messages: {
       retrieve: vi.fn().mockResolvedValue({ id: 'msg-1', status: 'DELIVERED' }),

--- a/mcp/src/__tests__/integration.test.ts
+++ b/mcp/src/__tests__/integration.test.ts
@@ -98,7 +98,7 @@ describe('MCP protocol', () => {
 
   it('listTools returns all tools with descriptions', async () => {
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(124);
+    expect(tools.length).toBe(141);
     for (const tool of tools) {
       expect(tool.name).toBeTruthy();
       expect(tool.description).toBeTruthy();

--- a/mcp/src/__tests__/tools-coverage.test.ts
+++ b/mcp/src/__tests__/tools-coverage.test.ts
@@ -697,6 +697,99 @@ describe('Tool coverage - one call per tool', () => {
     expect(mockCourier.providers.catalog.list).toHaveBeenCalled();
   });
 
+  // --- Preference Sections (raw HTTP escape hatch) ---
+
+  it('list_preference_sections', async () => {
+    await client.callTool({ name: 'list_preference_sections', arguments: {} });
+    expect(mockCourier.get).toHaveBeenCalledWith('/preferences/sections');
+  });
+
+  it('create_preference_section', async () => {
+    await client.callTool({ name: 'create_preference_section', arguments: { name: 'Account', routing_options: ['email'] } });
+    expect(mockCourier.post).toHaveBeenCalledWith('/preferences/sections', { body: expect.objectContaining({ name: 'Account', routing_options: ['email'] }) });
+  });
+
+  it('get_preference_section', async () => {
+    await client.callTool({ name: 'get_preference_section', arguments: { section_id: 'sec-1' } });
+    expect(mockCourier.get).toHaveBeenCalledWith('/preferences/sections/sec-1');
+  });
+
+  it('replace_preference_section', async () => {
+    await client.callTool({ name: 'replace_preference_section', arguments: { section_id: 'sec-1', name: 'Renamed' } });
+    expect(mockCourier.put).toHaveBeenCalledWith('/preferences/sections/sec-1', { body: expect.objectContaining({ name: 'Renamed' }) });
+  });
+
+  it('archive_preference_section', async () => {
+    await client.callTool({ name: 'archive_preference_section', arguments: { section_id: 'sec-1' } });
+    expect(mockCourier.delete).toHaveBeenCalledWith('/preferences/sections/sec-1');
+  });
+
+  it('publish_preferences', async () => {
+    await client.callTool({ name: 'publish_preferences', arguments: {} });
+    expect(mockCourier.post).toHaveBeenCalledWith('/preferences/publish');
+  });
+
+  it('list_preference_topics', async () => {
+    await client.callTool({ name: 'list_preference_topics', arguments: { section_id: 'sec-1' } });
+    expect(mockCourier.get).toHaveBeenCalledWith('/preferences/sections/sec-1/topics');
+  });
+
+  it('create_preference_topic', async () => {
+    await client.callTool({ name: 'create_preference_topic', arguments: { section_id: 'sec-1', name: 'Marketing', default_status: 'OPTED_OUT' } });
+    expect(mockCourier.post).toHaveBeenCalledWith('/preferences/sections/sec-1/topics', { body: expect.objectContaining({ name: 'Marketing', default_status: 'OPTED_OUT' }) });
+  });
+
+  it('get_preference_topic', async () => {
+    await client.callTool({ name: 'get_preference_topic', arguments: { section_id: 'sec-1', topic_id: 'top-1' } });
+    expect(mockCourier.get).toHaveBeenCalledWith('/preferences/sections/sec-1/topics/top-1');
+  });
+
+  it('replace_preference_topic', async () => {
+    await client.callTool({ name: 'replace_preference_topic', arguments: { section_id: 'sec-1', topic_id: 'top-1', name: 'Updates', default_status: 'OPTED_IN' } });
+    expect(mockCourier.put).toHaveBeenCalledWith('/preferences/sections/sec-1/topics/top-1', { body: expect.objectContaining({ name: 'Updates', default_status: 'OPTED_IN' }) });
+  });
+
+  it('archive_preference_topic', async () => {
+    await client.callTool({ name: 'archive_preference_topic', arguments: { section_id: 'sec-1', topic_id: 'top-1' } });
+    expect(mockCourier.delete).toHaveBeenCalledWith('/preferences/sections/sec-1/topics/top-1');
+  });
+
+  // --- Digests (raw HTTP escape hatch) ---
+
+  it('release_digest', async () => {
+    await client.callTool({ name: 'release_digest', arguments: { schedule_id: 'sch/abc' } });
+    expect(mockCourier.post).toHaveBeenCalledWith('/digests/schedules/sch%2Fabc/trigger');
+  });
+
+  it('list_digest_instances', async () => {
+    await client.callTool({ name: 'list_digest_instances', arguments: { schedule_id: 'sch/abc', limit: 50 } });
+    expect(mockCourier.get).toHaveBeenCalledWith('/digests/schedules/sch%2Fabc/instances', { query: expect.objectContaining({ limit: 50 }) });
+  });
+
+  // --- Journey template content (raw HTTP escape hatch) ---
+
+  it('get_journey_template_content', async () => {
+    await client.callTool({ name: 'get_journey_template_content', arguments: { journey_id: 'j-1', notification_id: 'n-1', version: 'draft' } });
+    expect(mockCourier.get).toHaveBeenCalledWith('/journeys/j-1/templates/n-1/content', { query: expect.objectContaining({ version: 'draft' }) });
+  });
+
+  it('put_journey_template_content', async () => {
+    await client.callTool({ name: 'put_journey_template_content', arguments: { journey_id: 'j-1', notification_id: 'n-1', elements: [] } });
+    expect(mockCourier.put).toHaveBeenCalledWith('/journeys/j-1/templates/n-1/content', { body: expect.objectContaining({ content: { elements: [] } }) });
+  });
+
+  it('put_journey_template_locale', async () => {
+    await client.callTool({ name: 'put_journey_template_locale', arguments: { journey_id: 'j-1', notification_id: 'n-1', locale_id: 'es', elements: [{ id: 'e-1' }] } });
+    expect(mockCourier.put).toHaveBeenCalledWith('/journeys/j-1/templates/n-1/locales/es', { body: expect.objectContaining({ elements: [{ id: 'e-1' }] }) });
+  });
+
+  // --- Users (raw HTTP escape hatch) ---
+
+  it('delete_user_preference_topic', async () => {
+    await client.callTool({ name: 'delete_user_preference_topic', arguments: { user_id: 'u-1', topic_id: 'top-1' } });
+    expect(mockCourier.delete).toHaveBeenCalledWith('/users/u-1/preferences/top-1');
+  });
+
   // --- Config (diagnostic, not in defaultTools) ---
 
   it('get_environment_config returns masked key and session info', async () => {
@@ -920,7 +1013,7 @@ describe('Tool filtering - registerToolIfNeeded respects availableTools', () => 
       const tools = await client.listTools();
       const names = tools.tools.map((t: any) => t.name);
       expect(names).not.toContain('get_environment_config');
-      expect(names.length).toBe(123);
+      expect(names.length).toBe(140);
     } finally {
       await cleanup();
     }
@@ -933,7 +1026,7 @@ describe('Tool filtering - registerToolIfNeeded respects availableTools', () => 
       const tools = await client.listTools();
       const names = tools.tools.map((t: any) => t.name);
       expect(names).toContain('get_environment_config');
-      expect(names.length).toBe(124);
+      expect(names.length).toBe(141);
     } finally {
       await cleanup();
     }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -24,6 +24,8 @@ import { RequestsTools } from './tools/requests-tools.js';
 import { RoutingStrategiesTools } from './tools/routing-strategies-tools.js';
 import { JourneysTools } from './tools/journeys-tools.js';
 import { ProvidersTools } from './tools/providers-tools.js';
+import { PreferenceSectionsTools } from './tools/preference-sections-tools.js';
+import { DigestsTools } from './tools/digests-tools.js';
 
 import { CourierMcpConfig } from './utils/config.js';
 import { MCP_DETAILS, PACKAGE_NAME, PACKAGE_VERSION } from './utils/version.js';
@@ -66,6 +68,8 @@ export default class CourierMcp extends McpServer {
     new RoutingStrategiesTools(this).register();
     new JourneysTools(this).register();
     new ProvidersTools(this).register();
+    new PreferenceSectionsTools(this).register();
+    new DigestsTools(this).register();
   }
 }
 

--- a/mcp/src/policy/recommended-client-disabled-tools.ts
+++ b/mcp/src/policy/recommended-client-disabled-tools.ts
@@ -6,6 +6,8 @@ import { SendTools } from "../tools/send-tools.js";
  */
 const DESTRUCTIVE_HINT_TOOLS: readonly string[] = [
   "archive_notification",
+  "archive_preference_section",
+  "archive_preference_topic",
   "archive_request",
   "archive_routing_strategy",
   "cancel_message",
@@ -18,6 +20,7 @@ const DESTRUCTIVE_HINT_TOOLS: readonly string[] = [
   "delete_tenant",
   "delete_tenant_preference",
   "delete_user_list_subscriptions",
+  "delete_user_preference_topic",
   "delete_user_token",
   "remove_all_user_tenants",
   "remove_user_from_tenant",

--- a/mcp/src/tools/digests-tools.ts
+++ b/mcp/src/tools/digests-tools.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { CourierMcpTools } from "./courier-mcp-tools.js";
+import { handleToolCall } from "../utils/error-handler.js";
+
+// NOTE: The published @trycourier/courier SDK does not yet expose a typed
+// `digests` resource. Until it is regenerated, these tools call the SDK's raw
+// HTTP methods. Swap to `this.mcp.courier.digests.schedules.*` when available.
+export class DigestsTools extends CourierMcpTools {
+
+  static readonly tools: string[] = [
+    'release_digest',
+    'list_digest_instances',
+  ];
+
+  public register() {
+
+    this.registerToolIfNeeded(
+      DigestsTools.tools[0],
+      'Release a digest schedule early — send what users have collected so far now instead of waiting for the scheduled time. A 204 is also returned when the schedule has no in-progress instances to release.',
+      {
+        schedule_id: z.string().describe('The digest schedule id, in the form "sch/{uuid}"'),
+      },
+      async ({ schedule_id }) => {
+        return handleToolCall(async () => {
+          await this.mcp.courier.post(`/digests/schedules/${encodeURIComponent(schedule_id)}/trigger`);
+          return { success: true, message: `Digest schedule ${schedule_id} released` };
+        });
+      },
+      { readOnlyHint: false, idempotentHint: false }
+    );
+
+    this.registerToolIfNeeded(
+      DigestsTools.tools[1],
+      'List the digest instances for a schedule. Each instance represents the events accumulated for a single user against the schedule, useful for monitoring accumulation before a digest is released.',
+      {
+        schedule_id: z.string().describe('The digest schedule id, in the form "sch/{uuid}"'),
+        cursor: z.string().optional().describe('Pagination cursor from a previous response'),
+        limit: z.number().optional().describe('Max instances to return (default 20, max 100)'),
+      },
+      async ({ schedule_id, cursor, limit }) => {
+        return handleToolCall(() => {
+          const query: Record<string, any> = {};
+          if (cursor) query.cursor = cursor;
+          if (limit) query.limit = limit;
+          return this.mcp.courier.get(`/digests/schedules/${encodeURIComponent(schedule_id)}/instances`, { query });
+        });
+      },
+      { readOnlyHint: true }
+    );
+  }
+}

--- a/mcp/src/tools/journeys-tools.ts
+++ b/mcp/src/tools/journeys-tools.ts
@@ -20,6 +20,9 @@ export class JourneysTools extends CourierMcpTools {
     'archive_journey_template',
     'publish_journey_template',
     'list_journey_template_versions',
+    'get_journey_template_content',
+    'put_journey_template_content',
+    'put_journey_template_locale',
   ];
 
   public register() {
@@ -314,6 +317,81 @@ export class JourneysTools extends CourierMcpTools {
         );
       },
       { readOnlyHint: true }
+    );
+
+    // The published SDK does not yet expose content/locale methods on
+    // journeys.templates, so these call the raw HTTP client. Migrate to
+    // `this.mcp.courier.journeys.templates.*` once the SDK is regenerated.
+
+    this.registerToolIfNeeded(
+      JourneysTools.tools[15],
+      'Fetch the elemental content of a journey-scoped notification template. Pass version=draft for the working draft, or vN for a historical version. Defaults to published.',
+      {
+        notification_id: z.string().describe('The notification template ID'),
+        journey_id: z.string().describe('The journey template ID that owns this notification'),
+        version: z.string().optional().describe('Version to retrieve: "draft", "published" (default), or a version string like "v001"'),
+      },
+      async ({ notification_id, journey_id, version }) => {
+        return handleToolCall(() => {
+          const query: Record<string, any> = {};
+          if (version) query.version = version;
+          return this.mcp.courier.get(
+            `/journeys/${encodeURIComponent(journey_id)}/templates/${encodeURIComponent(notification_id)}/content`,
+            { query }
+          );
+        });
+      },
+      { readOnlyHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      JourneysTools.tools[16],
+      'Replace the elemental content of a journey-scoped notification template. Overwrites all elements. Call publish_journey_template afterwards to make it live.',
+      {
+        notification_id: z.string().describe('The notification template ID'),
+        journey_id: z.string().describe('The journey template ID that owns this notification'),
+        elements: z.array(z.record(z.any())).describe('Array of elemental content nodes'),
+        version: z.string().optional().describe('Content version string (e.g. "2022-01-01"). Server defaults when omitted.'),
+        state: z.enum(['DRAFT', 'PUBLISHED']).optional().describe('Template state after update'),
+      },
+      async ({ notification_id, journey_id, elements, version, state }) => {
+        return handleToolCall(() => {
+          const content: Record<string, any> = { elements };
+          if (version !== undefined) content.version = version;
+          const body: Record<string, any> = { content };
+          if (state !== undefined) body.state = state;
+          return this.mcp.courier.put(
+            `/journeys/${encodeURIComponent(journey_id)}/templates/${encodeURIComponent(notification_id)}/content`,
+            { body }
+          );
+        });
+      },
+      { readOnlyHint: false, idempotentHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      JourneysTools.tools[17],
+      'Set locale-specific content overrides for a journey-scoped notification template. Each element override must reference an existing element by its id.',
+      {
+        notification_id: z.string().describe('The notification template ID'),
+        journey_id: z.string().describe('The journey template ID that owns this notification'),
+        locale_id: z.string().describe('Locale identifier (e.g. es, fr, pt-BR)'),
+        elements: z.array(z.object({
+          id: z.string().describe('Target element ID to override'),
+        }).catchall(z.any())).describe('Array of element overrides with id and locale-specific content'),
+        state: z.enum(['DRAFT', 'PUBLISHED']).optional().describe('Template state after update'),
+      },
+      async ({ notification_id, journey_id, locale_id, elements, state }) => {
+        return handleToolCall(() => {
+          const body: Record<string, any> = { elements };
+          if (state !== undefined) body.state = state;
+          return this.mcp.courier.put(
+            `/journeys/${encodeURIComponent(journey_id)}/templates/${encodeURIComponent(notification_id)}/locales/${encodeURIComponent(locale_id)}`,
+            { body }
+          );
+        });
+      },
+      { readOnlyHint: false, idempotentHint: true }
     );
   }
 }

--- a/mcp/src/tools/preference-sections-tools.ts
+++ b/mcp/src/tools/preference-sections-tools.ts
@@ -1,0 +1,217 @@
+import { z } from "zod";
+import { CourierMcpTools } from "./courier-mcp-tools.js";
+import { handleToolCall } from "../utils/error-handler.js";
+
+// NOTE: The published @trycourier/courier SDK does not yet expose a typed
+// `preferenceSections` resource (the endpoints are in the API spec but the SDK
+// has not been regenerated). Until it is, these tools call the SDK's raw HTTP
+// methods (`courier.post/get/put/delete`). When the typed resource ships, swap
+// these for `this.mcp.courier.preferenceSections.*` calls.
+const CHANNEL_CLASSIFICATIONS = ['direct_message', 'email', 'push', 'sms', 'webhook', 'inbox'] as const;
+
+export class PreferenceSectionsTools extends CourierMcpTools {
+
+  static readonly tools: string[] = [
+    'list_preference_sections',
+    'create_preference_section',
+    'get_preference_section',
+    'replace_preference_section',
+    'archive_preference_section',
+    'publish_preferences',
+    'list_preference_topics',
+    'create_preference_topic',
+    'get_preference_topic',
+    'replace_preference_topic',
+    'archive_preference_topic',
+  ];
+
+  public register() {
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[0],
+      "List the workspace's preference sections. Each section embeds its topics.",
+      {},
+      async () => {
+        return handleToolCall(() => this.mcp.courier.get('/preferences/sections'));
+      },
+      { readOnlyHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[1],
+      'Create a preference section in your workspace. The section id is generated and returned. Add topics afterwards with create_preference_topic.',
+      {
+        name: z.string().describe('Human-readable name for the section'),
+        routing_options: z.array(z.enum(CHANNEL_CLASSIFICATIONS)).optional().describe('Default channels for the section. Defaults to empty if omitted.'),
+        has_custom_routing: z.boolean().optional().describe('Whether the section defines custom routing for its topics'),
+      },
+      async ({ name, routing_options, has_custom_routing }) => {
+        return handleToolCall(() => {
+          const body: Record<string, any> = { name };
+          if (routing_options !== undefined) body.routing_options = routing_options;
+          if (has_custom_routing !== undefined) body.has_custom_routing = has_custom_routing;
+          return this.mcp.courier.post('/preferences/sections', { body });
+        });
+      },
+      { readOnlyHint: false, idempotentHint: false }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[2],
+      'Retrieve a preference section by id, including its topics.',
+      {
+        section_id: z.string().describe('Id of the preference section'),
+      },
+      async ({ section_id }) => {
+        return handleToolCall(() => this.mcp.courier.get(`/preferences/sections/${encodeURIComponent(section_id)}`));
+      },
+      { readOnlyHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[3],
+      'Replace a preference section. Full document replacement; missing optional fields are cleared. Topics attached to the section are unaffected.',
+      {
+        section_id: z.string().describe('Id of the preference section'),
+        name: z.string().describe('Human-readable name for the section'),
+        routing_options: z.array(z.enum(CHANNEL_CLASSIFICATIONS)).optional().describe('Default channels for the section. Omit to clear.'),
+        has_custom_routing: z.boolean().optional().describe('Whether the section defines custom routing for its topics'),
+      },
+      async ({ section_id, name, routing_options, has_custom_routing }) => {
+        return handleToolCall(() => {
+          const body: Record<string, any> = { name };
+          if (routing_options !== undefined) body.routing_options = routing_options;
+          if (has_custom_routing !== undefined) body.has_custom_routing = has_custom_routing;
+          return this.mcp.courier.put(`/preferences/sections/${encodeURIComponent(section_id)}`, { body });
+        });
+      },
+      { readOnlyHint: false, idempotentHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[4],
+      'Archive a preference section. The section must be empty: delete its topics first, otherwise the request fails with 409.',
+      {
+        section_id: z.string().describe('Id of the preference section to archive'),
+      },
+      async ({ section_id }) => {
+        return handleToolCall(async () => {
+          await this.mcp.courier.delete(`/preferences/sections/${encodeURIComponent(section_id)}`);
+          return { success: true, message: `Preference section ${section_id} archived` };
+        });
+      },
+      { destructiveHint: true, idempotentHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[5],
+      "Publish the workspace's preferences page. Takes a snapshot of every section with its topics under a new published version, making the current state visible on the hosted preferences page.",
+      {},
+      async () => {
+        return handleToolCall(() => this.mcp.courier.post('/preferences/publish'));
+      },
+      { readOnlyHint: false, idempotentHint: false }
+    );
+
+    // --- Preference topic sub-resource tools ---
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[6],
+      'List the topics in a preference section.',
+      {
+        section_id: z.string().describe('Id of the preference section'),
+      },
+      async ({ section_id }) => {
+        return handleToolCall(() => this.mcp.courier.get(`/preferences/sections/${encodeURIComponent(section_id)}/topics`));
+      },
+      { readOnlyHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[7],
+      'Create a subscription preference topic inside a section. The topic id is generated and returned. Fails with 404 if the section does not exist.',
+      {
+        section_id: z.string().describe('Id of the preference section to create the topic in'),
+        name: z.string().describe('Human-readable name for the preference topic'),
+        default_status: z.enum(['OPTED_OUT', 'OPTED_IN', 'REQUIRED']).describe('Default subscription status applied when a recipient has not set their own'),
+        routing_options: z.array(z.enum(CHANNEL_CLASSIFICATIONS)).optional().describe('Default channels delivered for this topic. Defaults to empty if omitted.'),
+        allowed_preferences: z.array(z.enum(['snooze', 'channel_preferences'])).optional().describe('Preference controls a recipient may customize for this topic'),
+        include_unsubscribe_header: z.boolean().optional().describe('Whether to include a list-unsubscribe header on emails for this topic'),
+        topic_data: z.record(z.any()).optional().describe('Arbitrary metadata associated with the topic'),
+      },
+      async ({ section_id, name, default_status, routing_options, allowed_preferences, include_unsubscribe_header, topic_data }) => {
+        return handleToolCall(() => {
+          const body: Record<string, any> = { name, default_status };
+          if (routing_options !== undefined) body.routing_options = routing_options;
+          if (allowed_preferences !== undefined) body.allowed_preferences = allowed_preferences;
+          if (include_unsubscribe_header !== undefined) body.include_unsubscribe_header = include_unsubscribe_header;
+          if (topic_data !== undefined) body.topic_data = topic_data;
+          return this.mcp.courier.post(`/preferences/sections/${encodeURIComponent(section_id)}/topics`, { body });
+        });
+      },
+      { readOnlyHint: false, idempotentHint: false }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[8],
+      'Retrieve a topic within a section. Returns 404 if the section or topic does not exist, or the topic belongs to a different section.',
+      {
+        section_id: z.string().describe('Id of the preference section'),
+        topic_id: z.string().describe('Id of the subscription preference topic'),
+      },
+      async ({ section_id, topic_id }) => {
+        return handleToolCall(() =>
+          this.mcp.courier.get(`/preferences/sections/${encodeURIComponent(section_id)}/topics/${encodeURIComponent(topic_id)}`)
+        );
+      },
+      { readOnlyHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[9],
+      'Replace a topic within a section. Full document replacement; missing optional fields are cleared.',
+      {
+        section_id: z.string().describe('Id of the preference section'),
+        topic_id: z.string().describe('Id of the subscription preference topic'),
+        name: z.string().describe('Human-readable name for the preference topic'),
+        default_status: z.enum(['OPTED_OUT', 'OPTED_IN', 'REQUIRED']).describe('Default subscription status applied when a recipient has not set their own'),
+        routing_options: z.array(z.enum(CHANNEL_CLASSIFICATIONS)).optional().describe('Default channels delivered for this topic. Omit to clear.'),
+        allowed_preferences: z.array(z.enum(['snooze', 'channel_preferences'])).optional().describe('Preference controls a recipient may customize. Omit to clear.'),
+        include_unsubscribe_header: z.boolean().optional().describe('Whether to include a list-unsubscribe header on emails for this topic'),
+        topic_data: z.record(z.any()).optional().describe('Arbitrary metadata associated with the topic. Omit to clear.'),
+      },
+      async ({ section_id, topic_id, name, default_status, routing_options, allowed_preferences, include_unsubscribe_header, topic_data }) => {
+        return handleToolCall(() => {
+          const body: Record<string, any> = { name, default_status };
+          if (routing_options !== undefined) body.routing_options = routing_options;
+          if (allowed_preferences !== undefined) body.allowed_preferences = allowed_preferences;
+          if (include_unsubscribe_header !== undefined) body.include_unsubscribe_header = include_unsubscribe_header;
+          if (topic_data !== undefined) body.topic_data = topic_data;
+          return this.mcp.courier.put(
+            `/preferences/sections/${encodeURIComponent(section_id)}/topics/${encodeURIComponent(topic_id)}`,
+            { body }
+          );
+        });
+      },
+      { readOnlyHint: false, idempotentHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      PreferenceSectionsTools.tools[10],
+      'Archive a topic within a section.',
+      {
+        section_id: z.string().describe('Id of the preference section'),
+        topic_id: z.string().describe('Id of the subscription preference topic to archive'),
+      },
+      async ({ section_id, topic_id }) => {
+        return handleToolCall(async () => {
+          await this.mcp.courier.delete(
+            `/preferences/sections/${encodeURIComponent(section_id)}/topics/${encodeURIComponent(topic_id)}`
+          );
+          return { success: true, message: `Preference topic ${topic_id} archived` };
+        });
+      },
+      { destructiveHint: true, idempotentHint: true }
+    );
+  }
+}

--- a/mcp/src/tools/users-tools.ts
+++ b/mcp/src/tools/users-tools.ts
@@ -8,6 +8,7 @@ export class UsersTools extends CourierMcpTools {
     'get_user_preferences',
     'get_user_preference_topic',
     'update_user_preference_topic',
+    'delete_user_preference_topic',
     'list_user_tenants',
     'add_user_to_tenant',
     'remove_user_from_tenant',
@@ -76,6 +77,24 @@ export class UsersTools extends CourierMcpTools {
 
     this.registerToolIfNeeded(
       UsersTools.tools[3],
+      "Delete a user's preference for a specific subscription topic, reverting it to the topic's default status.",
+      {
+        user_id: z.string().describe('The user ID'),
+        topic_id: z.string().describe('The subscription topic ID'),
+      },
+      async ({ user_id, topic_id }) => {
+        return handleToolCall(async () => {
+          await this.mcp.courier.delete(
+            `/users/${encodeURIComponent(user_id)}/preferences/${encodeURIComponent(topic_id)}`
+          );
+          return { success: true, message: `Preference for topic ${topic_id} deleted for user ${user_id}` };
+        });
+      },
+      { destructiveHint: true, idempotentHint: true }
+    );
+
+    this.registerToolIfNeeded(
+      UsersTools.tools[4],
       "List all tenants a user belongs to.",
       {
         user_id: z.string().describe('The user ID'),
@@ -94,7 +113,7 @@ export class UsersTools extends CourierMcpTools {
     );
 
     this.registerToolIfNeeded(
-      UsersTools.tools[4],
+      UsersTools.tools[5],
       'Add a user to a tenant.',
       {
         user_id: z.string().describe('The user ID'),
@@ -113,7 +132,7 @@ export class UsersTools extends CourierMcpTools {
     );
 
     this.registerToolIfNeeded(
-      UsersTools.tools[5],
+      UsersTools.tools[6],
       'Remove a user from a tenant.',
       {
         user_id: z.string().describe('The user ID'),
@@ -129,7 +148,7 @@ export class UsersTools extends CourierMcpTools {
     );
 
     this.registerToolIfNeeded(
-      UsersTools.tools[6],
+      UsersTools.tools[7],
       'Add a user to multiple tenants at once. A custom profile can be supplied per tenant.',
       {
         user_id: z.string().describe('The user ID'),
@@ -148,7 +167,7 @@ export class UsersTools extends CourierMcpTools {
     );
 
     this.registerToolIfNeeded(
-      UsersTools.tools[7],
+      UsersTools.tools[8],
       'Remove a user from all tenants.',
       {
         user_id: z.string().describe('The user ID'),

--- a/mcp/src/utils/courier-mcp-tools-registry.ts
+++ b/mcp/src/utils/courier-mcp-tools-registry.ts
@@ -20,6 +20,8 @@ import { RequestsTools } from "../tools/requests-tools.js";
 import { RoutingStrategiesTools } from "../tools/routing-strategies-tools.js";
 import { JourneysTools } from "../tools/journeys-tools.js";
 import { ProvidersTools } from "../tools/providers-tools.js";
+import { PreferenceSectionsTools } from "../tools/preference-sections-tools.js";
+import { DigestsTools } from "../tools/digests-tools.js";
 
 export class CourierMcpToolsRegistry {
 
@@ -50,6 +52,8 @@ export class CourierMcpToolsRegistry {
       ...RoutingStrategiesTools.tools,
       ...JourneysTools.tools,
       ...ProvidersTools.tools,
+      ...PreferenceSectionsTools.tools,
+      ...DigestsTools.tools,
     ];
   }
 


### PR DESCRIPTION
## What

Adds **17 MCP tools** for Courier API endpoints that exist in the [api-spec](https://github.com/trycourier/api-spec) but had no corresponding tool. Tool count goes **124 → 141** (140 default + 1 diagnostic).

| Resource | Tools added |
|---|---|
| Preference Sections | `list`/`create`/`get`/`replace`/`archive_preference_section`, `publish_preferences` |
| Preference Topics | `list`/`create`/`get`/`replace`/`archive_preference_topic` |
| Digests | `release_digest`, `list_digest_instances` |
| Journey template content | `get`/`put_journey_template_content`, `put_journey_template_locale` |
| Users | `delete_user_preference_topic` |

## Why the raw HTTP client

The published `@trycourier/courier@7.11.0` (also the latest on npm) does **not** yet expose typed resources for these endpoints — the spec is ahead of the generated SDK. To ship the tools now, each new tool uses the SDK's raw HTTP client (`courier.get/post/put/delete`) while following all existing conventions (per-resource `*Tools` class, `registerToolIfNeeded`, `handleToolCall`, zod schemas, annotations). Each file notes that these should migrate to typed `courier.*` calls once the SDK is regenerated.

## Also updated

- Registry + index registration for the two new tool classes
- `RECOMMENDED_CLIENT_DISABLED_TOOLS` (3 new destructive tools)
- README counts/tables + both plugin manifests (124 → 141)
- 17 new per-tool coverage tests

## Testing

`npm run build` clean; **221/221 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)