### PR TITLE
fix(server): stop Cursor 404 error on OAuth discovery probes

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,6 +56,29 @@ app.get('/.well-known/mcp/server-card.json', (_req: Request, res: Response) => {
   });
 });
 
+// Some MCP clients (notably Cursor) proactively probe OAuth 2.0 discovery
+// endpoints on connect — even for a server like this one that authenticates with
+// an `api_key` header and implements no OAuth. With no route registered, Express
+// answers these probes with its default 404 whose body is HTML. Cursor's client
+// tries to parse that body as JSON and crashes ("Unexpected non-whitespace
+// character after JSON"), which surfaces to the user as a 404 connection error.
+//
+// RFC 9728 says the *absence* of OAuth metadata (a 404) is the correct signal
+// that OAuth is unsupported, and a spec-compliant client treats the 404 as "no
+// auth server, fall back to configured credentials". So the 404 status is right;
+// we just need a JSON body so the probe parses cleanly. We answer every OAuth /
+// OpenID discovery probe (and dynamic client registration) with a 404 + JSON.
+const oauthNotSupported = (_req: Request, res: Response) => {
+  res
+    .status(404)
+    .json({ message: 'OAuth is not supported. Authenticate with the api_key header.' });
+};
+app.all(
+  /^\/\.well-known\/(oauth-authorization-server|oauth-protected-resource|openid-configuration)(\/.*)?$/,
+  oauthNotSupported
+);
+app.all('/register', oauthNotSupported);
+
 app.get('/health', (_req, res) => {
   res.status(200).send('OK');
 });


### PR DESCRIPTION
## The bug

Connecting the hosted MCP server in **Cursor** surfaces a **404 error**, even though the server works with the configured `api_key` header.

## Root cause

Cursor proactively probes OAuth 2.0 / OpenID discovery endpoints on connect — `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`, `/.well-known/openid-configuration`, and the dynamic-registration endpoint `POST /register` — before falling back to header auth. This server authenticates with an `api_key` header and implements **no OAuth**, so none of those routes exist.

With no route registered, Express answers each probe with its **default 404 whose body is HTML**. Cursor's client tries to parse that body as JSON and crashes with `Unexpected non-whitespace character after JSON`, which surfaces to the user as the 404 error. (See the [Cursor forum thread](https://forum.cursor.com/t/mcp-oauth-fails-with-404-error/156925) and [this writeup](https://ainoya.dev/posts/fixing-invalid-oauth-error-response-when-connecting-cursor-to-a-custom-mcp-server/).)

## Fix

Register handlers for those probe paths that return **404 with a JSON body** instead of HTML:

```json
{ "message": "OAuth is not supported. Authenticate with the api_key header." }
```

Per **RFC 9728**, the absence of OAuth metadata (a 404) is the correct signal that OAuth is unsupported — so the status stays 404 and spec-compliant clients fall back to the configured credentials. The reference `@modelcontextprotocol/sdk` already treats a 404 here as "no auth server" *without* reading the body; this change makes the response safe for clients (Cursor) that parse the body regardless. No auth-loop risk from switching to 401.

## Verified locally

| Request | Before | After |
|---|---|---|
| `GET /.well-known/oauth-authorization-server` | 404 `text/html` | **404 `application/json`** ✅ |
| `GET /.well-known/oauth-protected-resource` | 404 `text/html` | **404 `application/json`** ✅ |
| `GET /.well-known/openid-configuration` | 404 `text/html` | **404 `application/json`** ✅ |
| `POST /register` | 404 `text/html` | **404 `application/json`** ✅ |
| `POST /` (initialize) | 200 | 200 (unchanged) |
| `GET /` | 405 | 405 (unchanged) |
| `GET /.well-known/mcp/server-card.json` | 200 | 200 (unchanged — not shadowed by the new route) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)