### PR TITLE
fix(server): route all MCP-endpoint methods through the stateless handler (Cursor 404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cd courier-mcp
 sh dev.sh
 ```
 
-Then point your IDE at `http://localhost:3000` with the same config format above.
+Then point your IDE at `http://localhost:3939` with the same config format above.
 
 ## Tools
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,17 @@ import CourierMcp, { CourierMcpLogLevel, CourierMcpConfig, CourierMcpTools, PACK
 const app = express();
 app.use(express.json());
 
-app.post('/', (req: Request, res: Response, next: NextFunction) => {
+// The single MCP endpoint. Per the MCP Streamable HTTP transport spec, this path
+// must accept POST (JSON-RPC) and answer GET/DELETE with 405 — GET is the client's
+// OPTIONAL server-to-client SSE stream, which a stateless server doesn't offer, and
+// DELETE is client session termination, which we don't support. `statelessHandler`
+// already does all of this: it dispatches POST to the MCP server and returns a
+// spec-compliant 405 for any other method. Routing every method through the one
+// handler (instead of hand-rolling separate 405 routes) means the 405 can't be
+// dropped by accident — a missing GET route falls through to Express's default 404,
+// which MCP clients treat as a fatal "Failed to open SSE stream".
+// Spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+const mcpHandler = (req: Request, res: Response, next: NextFunction) => {
   const createServer = () => {
     const config = new CourierMcpConfig({
       headers: req.headers,
@@ -15,22 +25,11 @@ app.post('/', (req: Request, res: Response, next: NextFunction) => {
     return new CourierMcp(config);
   };
   return statelessHandler(createServer)(req, res, next);
-});
+};
 
-// MCP clients open an OPTIONAL standalone GET SSE stream to receive
-// server-initiated messages. A stateless server never pushes anything on it, so
-// we don't offer one. The MCP SDK client treats a 405 here as the documented
-// "no SSE stream at this endpoint" signal and continues cleanly; it only fails
-// fatally ("Failed to open SSE stream") on other non-2xx codes — notably the
-// Express-default 404 you get when this route is missing entirely. So the route
-// must exist and answer 405.
-app.get('/', (_req: Request, res: Response) => {
-  res.status(405).set('Allow', 'POST').send('SSE not supported on stateless server');
-});
-
-app.delete('/', (_req: Request, res: Response) => {
-  res.status(405).set('Allow', 'POST').send('Sessions not supported on stateless server');
-});
+app.post('/', mcpHandler);
+app.get('/', mcpHandler);
+app.delete('/', mcpHandler);
 
 app.get('/.well-known/mcp/server-card.json', (_req: Request, res: Response) => {
   res.json({
@@ -60,7 +59,7 @@ app.get('/health', (_req, res) => {
   res.status(200).send('OK');
 });
 
-const PORT = parseInt(process.env.PORT || '3000', 10);
+const PORT = parseInt(process.env.PORT || '3939', 10);
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`Stateless MCP server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Problem

Cursor (and other MCP clients) fail to connect to the hosted server with:

```
Error connecting to SSE server after fallback: SSE error: Non-200 status code (404)
Connection failed: SSE error: Non-200 status code (404)
```

The client opens an **SSE `GET`** on the MCP endpoint and receives a **404**, which it treats as fatal.

## Root cause

Per the [MCP Streamable HTTP transport spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports), the MCP endpoint must answer a `GET` (the client's optional server→client SSE stream) with either `text/event-stream` **or `405 Method Not Allowed`**. A stateless server never pushes on that stream, so **405** is correct. Any other non-2xx — notably Express's default **404** when no `GET` route is registered — is fatal to the client.

This dev server mounted `statelessHandler` only on `POST /` and hand-rolled *separate* `GET /` and `DELETE /` routes to emit those 405s. That parallel-route pattern is fragile — the exact thing that can be dropped and leave `GET /` falling through to a 404.

## Fix

`statelessHandler` already returns a spec-compliant 405 for any non-POST method. Route `POST` / `GET` / `DELETE` on `/` through the **one** handler instead of maintaining parallel 405 routes, so the behavior is owned by the handler and can't be dropped by accident.

Also bump the local dev port default `3000` → `3939` (+ README) to avoid colliding with other local dev servers.

## Verification

Local server (`:3939`):

| Method | Result |
|---|---|
| `POST /` initialize | 200 |
| `GET /` (SSE open) | **405** + JSON-RPC error body |
| `DELETE /` | **405** |
| `OPTIONS /` | 200, `Allow: POST,GET,HEAD,DELETE` (CORS preflight preserved) |

## Scope / follow-ups

- This is the **local dev server** (`server/`). It does **not** serve `mcp.courier.com`; the hosted server lives in `trycourier/services` (`apps/mcp/service/http-api/src/app.ts`).
- The production fix for this same issue already exists in that services app but is **uncommitted on `staging` / not yet deployed** — that deploy is what actually fixes users. This PR keeps the repo's reference/dev server correct and in sync.
- The services app also fixes a *second* Cursor failure mode not covered here: OAuth/`/register` discovery probes returning an HTML-bodied 404 that Cursor's client crashes parsing as JSON. Porting that handler into `server/` is a possible follow-up.
- No `@trycourier/courier-mcp` package change is needed — this is entirely the HTTP/Express layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)